### PR TITLE
Fix redis deprecation warnings

### DIFF
--- a/lib/pesto/lock.rb
+++ b/lib/pesto/lock.rb
@@ -82,9 +82,9 @@ module Pesto
       timeout_lock_expire = opts[:timeout_lock_expire]
 
       cp.with do |rc|
-        res = rc.multi do
+        res = rc.multi do |pipeline|
           names.each do |n|
-            res << rc.evalsha(@script_sha, {
+            res << pipeline.evalsha(@script_sha, {
               :keys => [lock_hash(n)],
               :argv => [timeout_lock_expire]
             })
@@ -118,9 +118,9 @@ module Pesto
       res = []
 
       cp.with do |rc|
-        res = rc.multi do
+        res = rc.multi do |pipeline|
           names.each do |n|
-            rc.del(lock_hash(n))
+            pipeline.del(lock_hash(n))
           end
         end
       end

--- a/lib/pesto/version.rb
+++ b/lib/pesto/version.rb
@@ -1,3 +1,3 @@
 module Pesto
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 end


### PR DESCRIPTION
Fix redis deprecation warning.

The following syntax is deprecated:

redis.multi do
  redis...
end

The syntax for redis 5 will be:
redis.multi do |pipeline|
  pipeline...
end